### PR TITLE
Simplifying testTrade

### DIFF
--- a/etherdelta.sol
+++ b/etherdelta.sol
@@ -279,11 +279,9 @@ contract EtherDelta is SafeMath {
   }
 
   function testTrade(address tokenGet, uint amountGet, address tokenGive, uint amountGive, uint expires, uint nonce, address user, uint8 v, bytes32 r, bytes32 s, uint amount, address sender) constant returns(bool) {
-    if (!(
+    return
       tokens[tokenGet][sender] >= amount &&
-      availableVolume(tokenGet, amountGet, tokenGive, amountGive, expires, nonce, user, v, r, s) >= amount
-    )) return false;
-    return true;
+      availableVolume(tokenGet, amountGet, tokenGive, amountGive, expires, nonce, user, v, r, s) >= amount;
   }
 
   function availableVolume(address tokenGet, uint amountGet, address tokenGive, uint amountGive, uint expires, uint nonce, address user, uint8 v, bytes32 r, bytes32 s) constant returns(uint) {


### PR DESCRIPTION
No need to return true/false explicitly when you can just return the (non-negated) value of the expression in the if statement.